### PR TITLE
Fix plugin.gd for Godot 4.3

### DIFF
--- a/addons/BetterTabContainer/plugin.gd
+++ b/addons/BetterTabContainer/plugin.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 


### PR DESCRIPTION
plugin.gd failed to be enabled from the plugins tab in project settings. Changing the first line from "tool" to "@tool" fixed the problem when working in Godot 4.3. Plugin now works as expected.